### PR TITLE
chore: Configure edge runtime for API routes

### DIFF
--- a/src/app/api/member/route.ts
+++ b/src/app/api/member/route.ts
@@ -4,8 +4,6 @@ import { currentUser } from '@clerk/nextjs';
 import { createInsertSchema } from 'drizzle-zod';
 import { z } from 'zod';
 
-export const runtime = 'edge';
-
 export async function POST(request: Request) {
     const req = await request.json();
     const schema = createInsertSchema(memberTable, {

--- a/src/app/api/member/route.ts
+++ b/src/app/api/member/route.ts
@@ -4,6 +4,8 @@ import { currentUser } from '@clerk/nextjs';
 import { createInsertSchema } from 'drizzle-zod';
 import { z } from 'zod';
 
+export const runtime = 'edge';
+
 export async function POST(request: Request) {
     const req = await request.json();
     const schema = createInsertSchema(memberTable, {

--- a/src/app/api/payment/route.ts
+++ b/src/app/api/payment/route.ts
@@ -17,6 +17,8 @@ import type { CreatePaymentLinkRequest } from 'square';
 import { ApiError } from 'square';
 import { z } from 'zod';
 
+export const runtime = 'edge';
+
 // Create a Square payment link
 // See: https://developer.squareup.com/reference/square/checkout-api/create-payment-link
 export async function POST(request: Request) {


### PR DESCRIPTION
### Description
Use edge runtimes for Vercel rather than the Node.js default to improve performance and better mitigate timeouts.

### Changes Made
Use edge runtimes for API routes
