### PR TITLE
build(ci): Use Github runner for production build

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     needs: lint-format
     name: Build
-    runs-on: [self-hosted, ARM64] # Since deployment is on arm64
+    runs-on: ubuntu-latest
     environment: Production
     permissions:
       id-token: write


### PR DESCRIPTION
### Description
Use Github runner for production build.

### Changes Made
Use Github runner ubuntu-latest rather than self-hosted arm64 runner for production build.

### Related Issues
N/A

### Additional Notes
N/A