### PR TITLE
build(ci): Optimise build workflow and use Github runner

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     needs: lint-format
     name: Build
-    runs-on: [self-hosted, ARM64] # Since deployment is on arm64
+    runs-on: ubuntu-latest
     environment: Production
     permissions:
       id-token: write
@@ -31,8 +31,21 @@ jobs:
           role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
           aws-region: ${{ env.AWS_REGION }}
 
-      # - name: Install arm64 support for Docker
-      #   run: docker run --privileged --rm tonistiigi/binfmt --install arm64
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Set up QEMU for ARM64
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: linux/arm64
+
+      - name: Cache Docker layers
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
 
       - name: Build Docker container
         env:
@@ -40,14 +53,24 @@ jobs:
           REDIS_URI: ${{ secrets.REDIS_URI }}
           NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
           NEXT_PUBLIC_DRIVE_LINK: ${{ secrets.NEXT_PUBLIC_DRIVE_LINK }}
+          PRODUCTION_BUILD: 'true'
         run: |
           docker buildx build \
+            --platform linux/arm64 \
+            --tag csclub-website:latest \
+            --cache-from=type=local,src=/tmp/.buildx-cache \
+            --cache-to=type=local,dest=/tmp/.buildx-cache-new,mode=max \
             --secret id=DATABASE_URL \
             --secret id=REDIS_URI \
             --secret id=NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY \
             --secret id=NEXT_PUBLIC_DRIVE_LINK \
-            --platform=linux/arm64 --file=Dockerfile -t csclub-website .
-          docker image save csclub-website | gzip > csclub-website.tar.gz
+            --file=Dockerfile -t csclub-website .
+            docker image save csclub-website | gzip > csclub-website.tar.gz
+
+      - name: Save Docker cache
+        if: success()
+        run: |
+          rsync -a --delete /tmp/.buildx-cache-new/ /tmp/.buildx-cache/
 
       - name: Copy image and compose file to S3
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ FROM node:22-bookworm-slim AS runner
 
 ENV PNPM_HOME="/root/.local/share/pnpm"
 ENV PATH="${PATH}:${PNPM_HOME}"
-ENV NODE_ENV production
+ENV NODE_ENV=production
 ENV NEXT_PUBLIC_CLERK_AFTER_SIGN_IN_URL=/
 ENV NEXT_PUBLIC_CLERK_AFTER_SIGN_UP_URL=/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 # Cache package.json
-FROM node:18-bookworm-slim AS deps
+FROM node:22-bookworm-slim AS deps
 
 WORKDIR /tmp
 
 COPY package.json ./
 
 # Build
-FROM node:18-bookworm-slim AS builder
+FROM node:22-bookworm-slim AS builder
 
 ENV PNPM_HOME="/root/.local/share/pnpm"
 ENV PATH="${PATH}:${PNPM_HOME}"
@@ -39,7 +39,7 @@ RUN --mount=type=secret,id=DATABASE_URL,target=/run/secrets/DATABASE_URL \
     pnpm run build
 
 # Final deployment image
-FROM node:18-bookworm-slim AS runner
+FROM node:22-bookworm-slim AS runner
 
 ENV PNPM_HOME="/root/.local/share/pnpm"
 ENV PATH="${PATH}:${PNPM_HOME}"

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -2,6 +2,7 @@ import './src/env.mjs';
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+    swcMinify: true,
     images: {
         remotePatterns: [
             {
@@ -9,6 +10,14 @@ const nextConfig = {
                 hostname: 'img.clerk.com',
             },
         ],
+    },
+    typescript: {
+        // Ignore TypeScript errors during production build
+        ignoreBuildErrors: process.env.PRODUCTION_BUILD === 'true',
+    },
+    eslint: {
+        // Ignore ESLint errors during production build
+        ignoreDuringBuilds: process.env.PRODUCTION_BUILD === 'true',
     },
 };
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "tsec --noEmit && next build",
+    "build": "next build",
     "analyse": "cross-env ANALYSE=true next build",
     "start": "next start",
     "lint": "cross-env SKIP_ENV_VALIDATION=true next lint",


### PR DESCRIPTION
### Description
Optimise build workflow and use Github runner to fix the server sometimes crashing during build requiring a full instance restart.

### Changes Made
- Used Node 22 rather than Node 18
- No typescript/eslint error checking for production workflow (I kept it for `ci-dev-pr` workflow since it's useful)
- Used SWC minify
- Removed tsec --noEmit from the build command
- Added build caching
- Switched to Github amd64 runner using QEMU rather than self-hosted arm64 runner

### Related Issues
N/A

### Additional Notes
N/A