### PR TITLE
fix(ci): Revert to node 18 to fix admin panel not working

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 # Cache package.json
-FROM node:22-bookworm-slim AS deps
+FROM node:18-bookworm-slim AS deps
 
 WORKDIR /tmp
 
 COPY package.json ./
 
 # Build
-FROM node:22-bookworm-slim AS builder
+FROM node:18-bookworm-slim AS builder
 
 ENV PNPM_HOME="/root/.local/share/pnpm"
 ENV PATH="${PATH}:${PNPM_HOME}"
@@ -39,7 +39,7 @@ RUN --mount=type=secret,id=DATABASE_URL,target=/run/secrets/DATABASE_URL \
     pnpm run build
 
 # Final deployment image
-FROM node:22-bookworm-slim AS runner
+FROM node:18-bookworm-slim AS runner
 
 ENV PNPM_HOME="/root/.local/share/pnpm"
 ENV PATH="${PATH}:${PNPM_HOME}"


### PR DESCRIPTION
### Description
Revert to node 18 to fix admin panel not working.

### Changes Made
Revert to node 18 in dockerfile.

### Related Issues
N/A

### Additional Notes
N/A