### PR TITLE
fix: prevent header text appear as two lines

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -36,7 +36,6 @@ export default async function Header() {
 
     return (
         <>
-            {/* prettier-ignore */}
             <HeaderClient data={headerData} className="hidden lg-xl:block" />
             <HeaderMobileClient data={headerData} className="lg-xl:hidden" />
         </>

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -36,8 +36,9 @@ export default async function Header() {
 
     return (
         <>
-            <HeaderClient data={headerData} className="hidden md:block" />
-            <HeaderMobileClient data={headerData} className="md:hidden" />
+            {/* prettier-ignore */}
+            <HeaderClient data={headerData} className="hidden lg-xl:block" />
+            <HeaderMobileClient data={headerData} className="lg-xl:hidden" />
         </>
     );
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -24,6 +24,7 @@ const config: Config = {
         // so a custom breakpoint was created to overwrite it
         // and now a CSS pattern can be applied with this breakpoint.
         'md-lg': '1169px',
+        'lg-xl': '1300px',
       },
     },
   },


### PR DESCRIPTION
### Description
To fix the issue when screen width is around 1300px and the header text will appear as two lines

### Changes Made
Added a breakpoint for hamburger menu at 1300px

### Related Issues
fix #173

### Additional Notes
N/A