### PR TITLE
fix(auth): Add trustHost option in NextAuth config

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -16,6 +16,7 @@ interface ExtendedSession extends Session {
 
 export const { handlers, signIn, signOut, auth } = NextAuth({
     providers: [Keycloak],
+    trustHost: true,
     callbacks: {
         async jwt({ token, user, account, profile }) {
             // Add user information to the JWT token


### PR DESCRIPTION
### Description
Add trustHost option in NextAuth config.

### Changes Made
Add trustHost option in NextAuth config.

### Related Issues
N/A

### Additional Notes
N/A