### PR TITLE
fix(env): Make NEXT_PUBLIC_DRIVE_LINK temporarily optional

### DIFF
--- a/src/env.mjs
+++ b/src/env.mjs
@@ -21,7 +21,7 @@ export const env = createEnv({
     client: {
         NEXT_PUBLIC_KEYCLOAK_REDIRECT_URI: z.string().url().min(1).optional(),
         NEXT_PUBLIC_AUTH_KEYCLOAK_ISSUER: z.string().url().min(1).optional(),
-        NEXT_PUBLIC_DRIVE_LINK: z.string().url().min(1),
+        NEXT_PUBLIC_DRIVE_LINK: z.string().url().min(1).optional(),
         NEXT_PUBLIC_UMAMI_WEBSITE_ID: z.string().optional(),
     },
     experimental__runtimeEnv: {


### PR DESCRIPTION
### Description
Make NEXT_PUBLIC_DRIVE_LINK temporarily optional in environment configuration.

### Changes Made
Make NEXT_PUBLIC_DRIVE_LINK temporarily optional in environment configuration.

### Related Issues
N/A

### Additional Notes
N/A