### PR TITLE
chore: Add postinstall script for git hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "db:generate": "drizzle-kit generate",
     "db:push": "drizzle-kit push",
     "db:studio": "drizzle-kit studio",
-    "email:dev": "email dev --dir=src/emails"
+    "email:dev": "email dev --dir=src/emails",
+    "postinstall": "npx simple-git-hooks"
   },
   "dependencies": {
     "@headlessui/react": "^2.2.0",


### PR DESCRIPTION
### Description
Add postinstall script for git hook to automatically install pre-commit git hook when you run `pnpm install`.

### Changes Made
Add postinstall script for git hook.

### Related Issues
Fixes #257 

### Additional Notes
N/A