### PR TITLE
feat(home): Link to main event card by clicking upcoming cards

### DIFF
--- a/src/app/(home)/UpcomingEventCard.tsx
+++ b/src/app/(home)/UpcomingEventCard.tsx
@@ -1,38 +1,41 @@
 import FancyRectangle from '@/components/FancyRectangle';
 import { type Event } from '@/data/events';
+import Link from 'next/link';
 import { FiClock, FiMapPin } from 'react-icons/fi';
 
 function UpcomingEventCard({ event, index }: { event: Event; index: number }) {
     return (
         <FancyRectangle colour="white" offset="8" rounded fullWidth>
             <div className="flex w-full flex-col gap-6 rounded-xl bg-white p-4 text-black lg:flex-row">
-                <div className="grow space-y-2 md:space-y-4">
-                    <div className="flex gap-6">
-                        <div
-                            className={`h-fit rounded-md border-[3px] border-black px-4 py-2 text-xl ${['bg-orange', 'bg-yellow', 'bg-purple'][index % 3]}`}
-                        >
-                            <div>{event.date.month}</div>
-                            <div>{event.date.day}</div>
-                        </div>
-                        <div className="grow space-y-2 text-2xl">
-                            <h4 className="md:border-b-[3px] md:border-black md:pb-1">
-                                {event.title}
-                            </h4>
-                            <div className="flex gap-2 text-lg font-normal">
-                                <span>
-                                    <FiClock size={26} />
-                                </span>
-                                <span>{event.time}</span>
+                <Link href={`/events#${event.title}-${event.date.year}`}>
+                    <div className="grow space-y-2 md:space-y-4">
+                        <div className="flex gap-6">
+                            <div
+                                className={`h-fit rounded-md border-[3px] border-black px-4 py-2 text-xl ${['bg-orange', 'bg-yellow', 'bg-purple'][index % 3]}`}
+                            >
+                                <div>{event.date.month}</div>
+                                <div>{event.date.day}</div>
                             </div>
-                            <div className="flex gap-2 text-lg font-normal">
-                                <span>
-                                    <FiMapPin size={26} />
-                                </span>
-                                <span>{event.location}</span>
+                            <div className="grow space-y-2 text-2xl">
+                                <h4 className="md:border-b-[3px] md:border-black md:pb-1">
+                                    {event.title}
+                                </h4>
+                                <div className="flex gap-2 text-lg font-normal">
+                                    <span>
+                                        <FiClock size={26} />
+                                    </span>
+                                    <span>{event.time}</span>
+                                </div>
+                                <div className="flex gap-2 text-lg font-normal">
+                                    <span>
+                                        <FiMapPin size={26} />
+                                    </span>
+                                    <span>{event.location}</span>
+                                </div>
                             </div>
                         </div>
                     </div>
-                </div>
+                </Link>
             </div>
         </FancyRectangle>
     );

--- a/src/app/(home)/UpcomingEventCard.tsx
+++ b/src/app/(home)/UpcomingEventCard.tsx
@@ -4,10 +4,12 @@ import Link from 'next/link';
 import { FiClock, FiMapPin } from 'react-icons/fi';
 
 function UpcomingEventCard({ event, index }: { event: Event; index: number }) {
+    const hyphenatedID = event.title.replaceAll(' ', '-');
+
     return (
         <FancyRectangle colour="white" offset="8" rounded fullWidth>
             <div className="flex w-full flex-col gap-6 rounded-xl bg-white p-4 text-black lg:flex-row">
-                <Link href={`/events#${event.title}-${event.date.year}`}>
+                <Link href={`/events#${hyphenatedID}-${event.date.year}`}>
                     <div className="grow space-y-2 md:space-y-4">
                         <div className="flex gap-6">
                             <div

--- a/src/app/events/EventCard.tsx
+++ b/src/app/events/EventCard.tsx
@@ -12,10 +12,11 @@ export default function EventCard({
     index: number;
     isPastEvent?: boolean;
 }) {
+    const hyphenatedID = event.title.replaceAll(' ', '-');
     return (
         <FancyRectangle colour="white" offset="8" rounded fullWidth>
             <div
-                id={`${event.title}-${event.date.year}`}
+                id={`${hyphenatedID}-${event.date.year}`}
                 className="flex w-full scroll-mt-[40vh] flex-col gap-6 rounded-xl bg-white p-4 text-black lg:flex-row"
             >
                 <Image

--- a/src/app/events/EventCard.tsx
+++ b/src/app/events/EventCard.tsx
@@ -14,7 +14,10 @@ export default function EventCard({
 }) {
     return (
         <FancyRectangle colour="white" offset="8" rounded fullWidth>
-            <div className="flex w-full flex-col gap-6 rounded-xl bg-white p-4 text-black lg:flex-row">
+            <div
+                id={`${event.title}-${event.date.year}`}
+                className="flex w-full scroll-mt-[40vh] flex-col gap-6 rounded-xl bg-white p-4 text-black lg:flex-row"
+            >
                 <Image
                     src={`/images/events/${event.image}`}
                     alt={`${event.title}`}


### PR DESCRIPTION
### Description

This pull request includes changes to the `UpcomingEventCard` and `EventCard` components to improve navigation and user experience. The most important changes are the addition of links to upcoming events and the introduction of scroll markers for event cards.

### Changes Made

Improvements to navigation:

* [`src/app/(home)/UpcomingEventCard.tsx`](diffhunk://#diff-b5eb29c424a2c44f932856ab2ad0f77c51ab64751e7d45ddf3d0fb85ef646c68R3-R10): Added a `Link` component around the event details to enable navigation to specific events based on their title and date. 

Enhancements to user experience:

* [`src/app/events/EventCard.tsx`](diffhunk://#diff-1d49e77c99df3cb7272ea708fb7aa8dc45a8d25bd12f22d453fbb8966b614965L17-R20): Introduced an `id` attribute to event cards to act as scroll markers, making it easier to navigate directly to specific events.

### Related Issues

feat #253 

### Additional Notes
By clicking the first upcoming card:
![Screenshot 2025-04-01 at 17 59 07](https://github.com/user-attachments/assets/ad098c4f-dadd-43b4-bfcb-8441de3cd71d)
By clicking the second upcoming card:
![Screenshot 2025-04-01 at 17 59 18](https://github.com/user-attachments/assets/e29d29be-2c59-4ec0-85e5-15fe5a2cd814)
By clicking the third upcoming card:
![Screenshot 2025-04-01 at 17 59 29](https://github.com/user-attachments/assets/b4fe6126-6820-42bd-8d9c-25f55b48b93b)
