### PR TITLE
fix(events): use correct end time from event.time

### DIFF
--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -6,7 +6,6 @@ import { fetchEvents, type Event } from '@/data/events';
 import { CAROUSEL_IMAGES } from '@/data/home';
 import { SPONSOR_TYPES, fetchSponsors } from '@/data/sponsors';
 import { payloadURL } from '@/lib/payload';
-import { getEventDate } from '@/utils/format-date';
 import Image from 'next/image';
 import Link from 'next/link';
 import { Fragment } from 'react';
@@ -14,8 +13,11 @@ import UpcomingEventCard from './UpcomingEventCard';
 
 export default async function HomePage() {
     const EVENTS: Event[] = await fetchEvents();
-    const CURRENT_TIME = new Date();
-    const UPCOMING_EVENTS = EVENTS.filter((event) => getEventDate(event) >= CURRENT_TIME);
+    // Get current date/time in Adelaide (Australia/Adelaide) timezone
+    const CURRENT_DATE = new Date(
+        new Date().toLocaleString('en-US', { timeZone: 'Australia/Adelaide' })
+    );
+    const UPCOMING_EVENTS = EVENTS.filter((event) => event.date.timestamp >= CURRENT_DATE);
 
     const sponsors = await fetchSponsors();
     return (

--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -6,14 +6,11 @@ import { fetchEvents, type Event } from '@/data/events';
 import { CAROUSEL_IMAGES } from '@/data/home';
 import { SPONSOR_TYPES, fetchSponsors } from '@/data/sponsors';
 import { payloadURL } from '@/lib/payload';
+import { getEventDate } from '@/utils/format-date';
 import Image from 'next/image';
 import Link from 'next/link';
 import { Fragment } from 'react';
 import UpcomingEventCard from './UpcomingEventCard';
-
-const getEventDate = (event: Event) => {
-    return new Date(`${event.date.year} ${event.date.month} ${event.date.day} ${event.endTime}`);
-};
 
 export default async function HomePage() {
     const EVENTS: Event[] = await fetchEvents();

--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -12,15 +12,13 @@ import { Fragment } from 'react';
 import UpcomingEventCard from './UpcomingEventCard';
 
 const getEventDate = (event: Event) => {
-    return new Date(
-        `${event.date.year} ${event.date.month} ${event.date.day} ${event.date.endTime}`
-    );
+    return new Date(`${event.date.year} ${event.date.month} ${event.date.day} ${event.endTime}`);
 };
 
 export default async function HomePage() {
     const EVENTS: Event[] = await fetchEvents();
-    const CURRENT_DATE = new Date();
-    const UPCOMING_EVENTS = EVENTS.filter((event) => getEventDate(event) >= CURRENT_DATE);
+    const CURRENT_TIME = new Date();
+    const UPCOMING_EVENTS = EVENTS.filter((event) => getEventDate(event) >= CURRENT_TIME);
 
     const sponsors = await fetchSponsors();
     return (

--- a/src/app/events/Events.tsx
+++ b/src/app/events/Events.tsx
@@ -4,7 +4,7 @@ import FancyRectangle from '@/components/FancyRectangle';
 import { type Event } from '@/data/events';
 import { fetchEvents } from '@/data/events';
 import { useMount } from '@/hooks/use-mount';
-import { DateTime } from 'luxon';
+import { getEventDate } from '@/utils/format-date';
 import { useState } from 'react';
 import { SkeletonLoader } from './EventSkeleton';
 import EventsByYear from './EventsByYear';
@@ -24,13 +24,6 @@ function Title({ children }: { children: string }) {
         </div>
     );
 }
-
-const getEventDate = (event: Event) => {
-    const dateStr = `${event.date.year}-${event.date.month}-${event.date.day}T${event.endTime}`;
-    return DateTime.fromFormat(dateStr, "yyyy-MMM-d'T'HH:mm", {
-        zone: 'Australia/Adelaide',
-    }).toJSDate();
-};
 
 export default function Events({ className }: { className?: string }) {
     const [loading, setLoading] = useState(true);

--- a/src/app/events/Events.tsx
+++ b/src/app/events/Events.tsx
@@ -4,7 +4,6 @@ import FancyRectangle from '@/components/FancyRectangle';
 import { type Event } from '@/data/events';
 import { fetchEvents } from '@/data/events';
 import { useMount } from '@/hooks/use-mount';
-import { getEventDate } from '@/utils/format-date';
 import { useState } from 'react';
 import { SkeletonLoader } from './EventSkeleton';
 import EventsByYear from './EventsByYear';
@@ -45,10 +44,9 @@ export default function Events({ className }: { className?: string }) {
 
         // Categorise events by year and whether they are upcoming or past
         EVENTS.forEach((event) => {
-            const eventDate = getEventDate(event);
             const year = event.date.year;
 
-            if (eventDate >= CURRENT_TIME) {
+            if (event.date.timestamp >= CURRENT_TIME) {
                 (upcomingEvents[year] ||= []).push(event);
             } else {
                 (pastEvents[year] ||= []).push(event);
@@ -56,10 +54,10 @@ export default function Events({ className }: { className?: string }) {
         });
 
         Object.values(upcomingEvents).forEach((events) =>
-            events.sort((a, b) => getEventDate(a).getTime() - getEventDate(b).getTime())
+            events.sort((a, b) => a.date.timestamp.getTime() - b.date.timestamp.getTime())
         );
         Object.values(pastEvents).forEach((events) =>
-            events.sort((a, b) => getEventDate(b).getTime() - getEventDate(a).getTime())
+            events.sort((a, b) => b.date.timestamp.getTime() - a.date.timestamp.getTime())
         );
 
         const getSortedYears = (events: Record<number, Event[]>) =>

--- a/src/app/events/Events.tsx
+++ b/src/app/events/Events.tsx
@@ -26,7 +26,7 @@ function Title({ children }: { children: string }) {
 }
 
 const getEventDate = (event: Event) => {
-    const dateStr = `${event.date.year}-${event.date.month}-${event.date.day}T${event.date.endTime}`;
+    const dateStr = `${event.date.year}-${event.date.month}-${event.date.day}T${event.endTime}`;
     return DateTime.fromFormat(dateStr, "yyyy-MMM-d'T'HH:mm", {
         zone: 'Australia/Adelaide',
     }).toJSDate();
@@ -43,8 +43,8 @@ export default function Events({ className }: { className?: string }) {
     });
 
     if (!loading) {
-        const CURRENT_DATE = new Date();
-        const CURRENT_YEAR = CURRENT_DATE.getFullYear();
+        const CURRENT_TIME = new Date();
+        const CURRENT_YEAR = CURRENT_TIME.getFullYear();
 
         // Create empty objects to hold upcoming and past events categorised by year
         const upcomingEvents: Record<number, Event[]> = {};
@@ -55,7 +55,7 @@ export default function Events({ className }: { className?: string }) {
             const eventDate = getEventDate(event);
             const year = event.date.year;
 
-            if (eventDate >= CURRENT_DATE) {
+            if (eventDate >= CURRENT_TIME) {
                 (upcomingEvents[year] ||= []).push(event);
             } else {
                 (pastEvents[year] ||= []).push(event);

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -118,8 +118,15 @@ export const parseEvents = (raw: PayloadEvent): Event => {
             ${new Date(raw.time.end).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })}`
             : 'Unknown',
         // endTime & startTime are in "HH:mm" 24-hour format (e.g., "21:00")
-        endTime: raw.time.end.toString().split(' - ')[1] ?? '21:00',
-        startTime: raw.time.start.toString().split(' - ')[1] ?? '00:00',
+        endTime: raw.time
+            ? new Date(raw.time.end).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })
+            : '21:00',
+        startTime: raw.time
+            ? new Date(raw.time.start).toLocaleTimeString([], {
+                  hour: 'numeric',
+                  minute: '2-digit',
+              })
+            : '00:00',
         location: raw.location,
         details: raw.details,
         url:

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -18,12 +18,14 @@ type Month =
 
 export type Event = {
     title: string;
-    date: { year: number; month: Month; day: number; endTime: string };
+    date: { year: number; month: Month; day: number };
     time: string;
     location: string;
     details: string;
     url?: { href: URL; text?: string };
     image: string;
+    startTime: string;
+    endTime: string;
 };
 
 // API response format from PayloadCMS
@@ -110,12 +112,14 @@ export const parseEvents = (raw: PayloadEvent): Event => {
             year: eventDate.getUTCFullYear(),
             month: monthNames[eventDate.getUTCMonth()],
             day: eventDate.getUTCDate(),
-            endTime: eventDate.toString().split(' - ')[1] ?? '21:00', // if undefined 9:00pm required for Events.tsx logic
         },
         time: raw.time
             ? `${new Date(raw.time.start).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })} - 
             ${new Date(raw.time.end).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })}`
             : 'Unknown',
+        // endTime & startTime are in "HH:mm" 24-hour format (e.g., "21:00")
+        endTime: raw.time.end.toString().split(' - ')[1] ?? '21:00',
+        startTime: raw.time.start.toString().split(' - ')[1] ?? '00:00',
         location: raw.location,
         details: raw.details,
         url:

--- a/src/utils/format-date.ts
+++ b/src/utils/format-date.ts
@@ -1,18 +1,7 @@
-import { type Event } from '@/data/events';
-import { DateTime } from 'luxon';
-
 // Function to format the date to DD/MM/YY format
 export const formatDate = (date: Date) => {
     const day = date.getDate().toString().padStart(2, '0');
     const month = (date.getMonth() + 1).toString().padStart(2, '0');
     const year = date.getFullYear().toString();
     return `${day}/${month}/${year}`;
-};
-
-// Returns a JS Date for an event's end time in Australia/Adelaide timezone
-export const getEventDate = (event: Event): Date => {
-    const dateStr = `${event.date.year}-${event.date.month}-${event.date.day}T${event.endTime}`;
-    return DateTime.fromFormat(dateStr, "yyyy-MMM-d'T'HH:mm", {
-        zone: 'Australia/Adelaide',
-    }).toJSDate();
 };

--- a/src/utils/format-date.ts
+++ b/src/utils/format-date.ts
@@ -1,7 +1,18 @@
+import { type Event } from '@/data/events';
+import { DateTime } from 'luxon';
+
 // Function to format the date to DD/MM/YY format
 export const formatDate = (date: Date) => {
     const day = date.getDate().toString().padStart(2, '0');
     const month = (date.getMonth() + 1).toString().padStart(2, '0');
     const year = date.getFullYear().toString();
     return `${day}/${month}/${year}`;
+};
+
+// Returns a JS Date for an event's end time in Australia/Adelaide timezone
+export const getEventDate = (event: Event): Date => {
+    const dateStr = `${event.date.year}-${event.date.month}-${event.date.day}T${event.endTime}`;
+    return DateTime.fromFormat(dateStr, "yyyy-MMM-d'T'HH:mm", {
+        zone: 'Australia/Adelaide',
+    }).toJSDate();
 };


### PR DESCRIPTION
### Description
Use end time from `event.time` instead of `event.date.endTime`.

### Changes Made
- Parse `startTime` and `endTime` from `event.time`
- Replace `CURRENT_DATE` with `CURRENT_TIME` to check both date and time

### Related Issues
#298

### Additional Notes
Added `startTime` and `endTime` attributes in `Event` for easier parsing