### PR TITLE
feat(layout): optimize sponsor display on mobile from single to doubl…

### DIFF
--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -248,7 +248,8 @@ export default async function HomePage() {
                                 <h3 className="text-center text-2xl font-black capitalize smr:text-left lg:text-3xl">
                                     {type} Sponsors
                                 </h3>
-                                <div className="flex flex-wrap justify-center gap-6 pb-2 smr:justify-start">
+                                {/* // 0–300px -> flex; 301–479px -> grid 2-cols; 480px+ -> flex */}
+                                <div className="flex flex-wrap justify-center gap-6 pb-2 xs:grid xs:grid-cols-2 smr:flex smr:flex-wrap smr:justify-start">
                                     {filteredSponsors.map(({ image, website, name }, i) => (
                                         <a
                                             href={website}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -19,6 +19,7 @@ const config: Config = {
         purple: '#7E7FE7',
       },
       screens: {
+        xs: '300px',
         smr: '480px',
         // There was a mysterious break point around 1169px in HeaderClient.tsx,
         // so a custom breakpoint was created to overwrite it


### PR DESCRIPTION
…e column



### Description
Optimize the home page sponsor display on mobile devices by adjusting the layout for different screen widths.


| Before | After |
|--------|-------|
| ![before](https://github.com/user-attachments/assets/c5432720-09c6-4bdd-b951-d4e4069060d7) | ![after](https://github.com/user-attachments/assets/cf8f2afc-d1a2-43c7-a496-40d73c2168cc) |


### Changes Made
1. Adding 'xs' breakpoint at 300px
2. Updated home page sponsor layout:
0–300px → flex
301–479px → grid with 2 columns
480px+ → flex
This allows sponsors to display in two columns on most mobile devices, improving readability.

### Related Issues
N/A

### Additional Notes
Not sure if this looks nicer to you guys, feel free to suggest.