### PR TITLE
fix: prevent events duplication by using React state

### DIFF
--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -248,7 +248,8 @@ export default async function HomePage() {
                                 <h3 className="text-center text-2xl font-black capitalize smr:text-left lg:text-3xl">
                                     {type} Sponsors
                                 </h3>
-                                <div className="flex flex-wrap justify-center gap-6 pb-2 smr:justify-start">
+                                {/* // 0–300px -> flex; 301–479px -> grid 2-cols; 480px+ -> flex */}
+                                <div className="flex flex-wrap justify-center gap-6 pb-2 xs:grid xs:grid-cols-2 smr:flex smr:flex-wrap smr:justify-start">
                                     {filteredSponsors.map(({ image, website, name }, i) => (
                                         <a
                                             href={website}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -19,6 +19,7 @@ const config: Config = {
         purple: '#7E7FE7',
       },
       screens: {
+        xs: '300px',
         smr: '480px',
         // There was a mysterious break point around 1169px in HeaderClient.tsx,
         // so a custom breakpoint was created to overwrite it


### PR DESCRIPTION
### Description
Refactor the Events component to use local state for EVENTS instead of a module-level array.

### Changes Made
Replaced 
```
const EVENTS: Event[] = [] 
```
with 
```
const [EVENTS, setEVENTS] = useState<Event[]>([])
```

### Related Issues
Fixes #295 

### Additional Notes
N/A