### PR TITLE
style: remove yaml from prettier format check

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "analyse": "cross-env ANALYSE=true next build",
     "start": "next start",
     "lint": "cross-env SKIP_ENV_VALIDATION=true eslint .",
-    "format": "prettier --write \"**/*.{js,jsx,ts,tsx,css,json,mjs,cjs,yml,yaml}\"",
-    "format:check": "prettier --check \"**/*.{js,jsx,ts,tsx,css,json,mjs,cjs,yml,yaml}\"",
+    "format": "prettier --write \"**/*.{js,jsx,ts,tsx,css,json,mjs,cjs}\"",
+    "format:check": "prettier --check \"**/*.{js,jsx,ts,tsx,css,json,mjs,cjs}\"",
     "db:generate": "drizzle-kit generate",
     "db:push": "drizzle-kit push",
     "db:studio": "drizzle-kit studio",
@@ -79,7 +79,7 @@
     "typescript": "^5.9.3"
   },
   "lint-staged": {
-    "*.{js,jsx,ts,tsx,css,json,mjs,cjs,yml,yaml}": [
+    "*.{js,jsx,ts,tsx,css,json,mjs,cjs}": [
       "prettier --write"
     ]
   },


### PR DESCRIPTION
### Description
*Remove YAML from the Prettier format and format check scripts to prevent Dependabot PRs from failing the lint check.*

### Changes Made
*Removed yml and yaml from the format script in package.json
Removed yml and yaml from the format:check script in package.json
Removed yml and yaml from the lint-staged config in package.json*

### Related Issues
*N/A*

### Additional Notes
*N/A*
