### PR TITLE
chore: Upgrade to pnpm 11 and add supply chain attack mitigations

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,9 +25,9 @@ updates:
           - version-update:semver-minor
           - version-update:semver-patch
 
-    # Wait 14 days before proposing any GitHub Actions version update.
+    # Wait 7 days before proposing any GitHub Actions version update.
     cooldown:
-      default-days: 14
+      default-days: 7
 
     # Group major action bumps into one PR to reduce clutter.
     groups:

--- a/.github/workflows/lint-and-format.yml
+++ b/.github/workflows/lint-and-format.yml
@@ -10,6 +10,8 @@ jobs:
     name: ESLint
     runs-on: ubuntu-latest
 
+    env:
+      SKIP_INSTALL_SIMPLE_GIT_HOOKS: '1'
     steps:
       - uses: actions/checkout@900f2210b1d28bbbd0bd22d17926b9e224e8f231
       - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e
@@ -22,6 +24,8 @@ jobs:
     name: Prettier
     runs-on: ubuntu-latest
 
+    env:
+      SKIP_INSTALL_SIMPLE_GIT_HOOKS: '1'
     steps:
       - uses: actions/checkout@900f2210b1d28bbbd0bd22d17926b9e224e8f231
       - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e

--- a/.github/workflows/lint-and-format.yml
+++ b/.github/workflows/lint-and-format.yml
@@ -14,8 +14,8 @@ jobs:
       - uses: actions/checkout@900f2210b1d28bbbd0bd22d17926b9e224e8f231
       - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e
         with:
-          version: 10
-      - run: pnpm install
+          version: 11
+      - run: pnpm install --frozen-lockfile --ignore-scripts
       - run: pnpm run lint
 
   prettier:
@@ -26,6 +26,6 @@ jobs:
       - uses: actions/checkout@900f2210b1d28bbbd0bd22d17926b9e224e8f231
       - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e
         with:
-          version: 10
-      - run: pnpm install
+          version: 11
+      - run: pnpm install --frozen-lockfile --ignore-scripts
       - run: pnpm run format:check

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ FROM node:25-trixie-slim AS builder
 ENV PNPM_HOME="/root/.local/share/pnpm"
 ENV PATH="${PATH}:${PNPM_HOME}"
 ENV SKIP_ENV_VALIDATION=true
+ENV SKIP_INSTALL_SIMPLE_GIT_HOOKS=1
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ COPY pnpm-lock.yaml ./
 COPY pnpm-workspace.yaml ./
 
 RUN npm install -g pnpm@11 \
-    && pnpm install
+    && pnpm install --frozen-lockfile
 
 COPY . .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ COPY --from=deps /tmp ./
 COPY pnpm-lock.yaml ./
 COPY pnpm-workspace.yaml ./
 
-RUN npm install -g pnpm \
+RUN npm install -g pnpm@11 \
     && pnpm install
 
 COPY . .
@@ -32,7 +32,7 @@ ENV PNPM_HOME="/root/.local/share/pnpm"
 ENV PATH="${PATH}:${PNPM_HOME}"
 ENV NODE_ENV=production
 
-RUN npm install -g pnpm
+RUN npm install -g pnpm@11
 
 WORKDIR /app
 

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get install -y sqlite3
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml drizzle.config.ts ./
 COPY src/db/schema.ts src/db/schema.ts
 
-RUN npm install -g pnpm && pnpm install
+RUN npm install -g pnpm@11 && pnpm install
 
 EXPOSE $PORT
 

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get install -y sqlite3
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml drizzle.config.ts ./
 COPY src/db/schema.ts src/db/schema.ts
 
-RUN npm install -g pnpm@11 && pnpm install
+RUN npm install -g pnpm@11 && pnpm install --frozen-lockfile
 
 EXPOSE $PORT
 

--- a/package.json
+++ b/package.json
@@ -85,15 +85,5 @@
   },
   "simple-git-hooks": {
     "pre-commit": "pnpm lint-staged"
-  },
-  "pnpm": {
-    "peerDependencyRules": {
-      "allowedVersions": {
-        "nodemailer": "8"
-      }
-    },
-    "onlyBuiltDependencies": [
-      "esbuild"
-    ]
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,3 +15,6 @@ overrides:
   "esbuild@^0.24.3": "^0.28.0"
   postcss@<8.5.10: "^8.5.10"
   protobufjs@<7.5.5: "^7.5.5"
+peerDependencyRules:
+  allowedVersions:
+    nodemailer: '8'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,10 +6,9 @@ allowBuilds:
   sharp: true
   simple-git-hooks: true
   unrs-resolver: true
-minimumReleaseAgeExclude:
-  - esbuild@0.24.3
-  - postcss@8.5.10
-  - protobufjs@7.5.5
+minimumReleaseAge: 7
+blockExoticSubdeps: true
+trustPolicy: no-downgrade
 overrides:
   esbuild@<=0.24.2: "^0.28.0"
   "esbuild@^0.24.3": "^0.28.0"


### PR DESCRIPTION
### Description
Upgrade to pnpm 11 and imporve supply chain attack mitigations.

### Changes Made
- Upgrade to pnpm 11
- Add supply chain attack mitigations
- Enforce frozen lockfile in workflows and Dockerfiles
- Skip Git hook for non-dev

### Related Issues
Fixes #300

### Additional Notes
N/A
